### PR TITLE
Transform Object.assign call

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,7 @@
     ]
   ],
   "plugins": [
-    "external-helpers"
+    "external-helpers",
+    "transform-object-assign"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Note that this origin should be whitelisted to access the NPO API.
 
 ## Browser support
 
-The NPO API Interceptor depends on two ES2015 features: Promise and Object.assign. Polyfills are not included, you need to polyfill these in your project, depending on your browser support level.
+The NPO API Interceptor depends on one ES2015 feature: Promises. A polyfills is not included, you need to polyfill it in your project, depending on your browser support level.
 
 ## Development
 

--- a/lib/npoapiinterceptor.browser.cjs.js
+++ b/lib/npoapiinterceptor.browser.cjs.js
@@ -75,6 +75,20 @@ var formatDate = function formatDate(date) {
   return date.toUTCString();
 };
 
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
 /**
  * NPO API Interceptor
  *
@@ -194,7 +208,7 @@ var createNpoApiInterceptor = function createNpoApiInterceptor(_ref) {
     }
 
     return Promise.resolve(config).then(function (config) {
-      return Object.assign({}, config, {
+      return _extends({}, config, {
         headers: getNpoApiHeaders(config)
       });
     });

--- a/lib/npoapiinterceptor.browser.es.js
+++ b/lib/npoapiinterceptor.browser.es.js
@@ -71,6 +71,20 @@ var formatDate = function formatDate(date) {
   return date.toUTCString();
 };
 
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
 /**
  * NPO API Interceptor
  *
@@ -190,7 +204,7 @@ var createNpoApiInterceptor = function createNpoApiInterceptor(_ref) {
     }
 
     return Promise.resolve(config).then(function (config) {
-      return Object.assign({}, config, {
+      return _extends({}, config, {
         headers: getNpoApiHeaders(config)
       });
     });

--- a/lib/npoapiinterceptor.cjs.js
+++ b/lib/npoapiinterceptor.cjs.js
@@ -73,6 +73,20 @@ var formatDate = function formatDate(date) {
   return date.toUTCString();
 };
 
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
 /**
  * NPO API Interceptor
  *
@@ -192,7 +206,7 @@ var createNpoApiInterceptor = function createNpoApiInterceptor(_ref) {
     }
 
     return Promise.resolve(config).then(function (config) {
-      return Object.assign({}, config, {
+      return _extends({}, config, {
         headers: getNpoApiHeaders(config)
       });
     });

--- a/lib/npoapiinterceptor.es.js
+++ b/lib/npoapiinterceptor.es.js
@@ -69,6 +69,20 @@ var formatDate = function formatDate(date) {
   return date.toUTCString();
 };
 
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
 /**
  * NPO API Interceptor
  *
@@ -188,7 +202,7 @@ var createNpoApiInterceptor = function createNpoApiInterceptor(_ref) {
     }
 
     return Promise.resolve(config).then(function (config) {
-      return Object.assign({}, config, {
+      return _extends({}, config, {
         headers: getNpoApiHeaders(config)
       });
     });

--- a/lib/npoapiinterceptor.js
+++ b/lib/npoapiinterceptor.js
@@ -74,6 +74,20 @@ var formatDate = function formatDate(date) {
   return date.toUTCString();
 };
 
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
 /**
  * NPO API Interceptor
  *
@@ -193,7 +207,7 @@ var createNpoApiInterceptor = function createNpoApiInterceptor(_ref) {
     }
 
     return Promise.resolve(config).then(function (config) {
-      return Object.assign({}, config, {
+      return _extends({}, config, {
         headers: getNpoApiHeaders(config)
       });
     });

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,6 +384,12 @@ babel-plugin-transform-es2015-unicode-regex@^6.22.0:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
+babel-plugin-transform-object-assign@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz#f99d2f66f1a0b0d498e346c5359684740caa20ba"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz#65740593a319c44522157538d690b84094617ea6"


### PR DESCRIPTION
Use a Babel plugin to transform the `Object.assign()` call to a little `_extends()` helper function. The `_extends` function will use the native `Object.assign()` if available or merge the objects itself if `Object.assign()` is not available.

This PR removes the need for consumers of this library to polyfill `Object.assign()` in order to use the NPO API Interceptor in browsers not supporting `Object.assign()`.